### PR TITLE
Make tests asynchronous

### DIFF
--- a/expand.py
+++ b/expand.py
@@ -1,3 +1,4 @@
+"""Expands the dictionary file performing the necessary modifications to make it more suitable for stemming"""
 # PREFIXES TO REMOVE
 PFX_TO_REMOVE = {
     'A': 're',
@@ -135,9 +136,11 @@ ADJUSTMENTS = {
 
 
 class Expander:
+    """Expands the dictionary file performing the necessary modifications to make it more suitable for stemming"""
     dictionary = {}
 
     def run(self):
+        """Performs the expansion"""
         self.load_original()
 
         # Stem *men -> *man, etc.
@@ -158,6 +161,11 @@ class Expander:
         self.write_new_dict()
 
     def process_word(self, word):
+        """
+        Processes a given word.
+        :param word: The word to process
+        :returns: List of words to remove from the dictionary
+        """
         remove_words = []
         for safe_end, (old_end, new_param) in NEW_STEMS.items():
             if word.endswith(safe_end):
@@ -168,6 +176,7 @@ class Expander:
         return remove_words
 
     def load_original(self):
+        """Loads in the original dictionary, removing prefix and suffixes defined above"""
         with open('en_US.dic.orig') as f:
             for line in f:
                 try:
@@ -199,6 +208,7 @@ class Expander:
                         self.dictionary[new_word] = params
 
     def write_new_dict(self):
+        """Writes the new dictionary to en_US.dic"""
         with open('en_US.dic', 'w') as f:
             words = sorted(self.dictionary.keys())
             f.write('%d\n' % (len(words)))

--- a/expand.py
+++ b/expand.py
@@ -188,13 +188,15 @@ class Expander:
                 for suffix in SFX_TO_REMOVE:
                     params = params.replace(suffix, '')
 
-                self.dictionary[word] = params
+                # Only add words longer than 1 char
+                if len(word) > 1:
+                    self.dictionary[word] = params
 
-                # Add new words
-                for new_word in new_words:
-                    if new_word in self.dictionary:
-                        params = ''.join(set(self.dictionary[new_word] + params))
-                    self.dictionary[new_word] = params
+                    # Add new words
+                    for new_word in new_words:
+                        if new_word in self.dictionary:
+                            params = ''.join(set(self.dictionary[new_word] + params))
+                        self.dictionary[new_word] = params
 
     def write_new_dict(self):
         with open('en_US.dic', 'w') as f:

--- a/tests.py
+++ b/tests.py
@@ -1,8 +1,14 @@
+"""Tests the effectiveness of the expanded library using tests.txt"""
 from multiprocessing.pool import Pool
 from subprocess import Popen, PIPE
 
 
 def stem(inp):
+    """
+    Calls the hunspell executable with the given input
+    :param inp: Word to give to hunspell
+    :return: Stem returned by hunspell
+    """
     process = Popen(
         args=['hunspell', '-m', '-d', 'en_US', '-s'],
         stdin=PIPE,
@@ -13,6 +19,11 @@ def stem(inp):
 
 
 def validate(line):
+    """
+    Test a given line
+    :param line: The line to test
+    :returns: (Result [bool], Error message [str])
+    """
     if line.startswith('#'):
         return
 
@@ -29,10 +40,16 @@ def validate(line):
 
 
 def assert_output(assertion, output_str):
+    """
+    Perform the assert call inside a method so yield can be used
+    :param assertion: Bool to be asserted
+    :param output_str: Error string if assertion fails
+    """
     assert assertion, output_str
 
 
 def test_stemming():
+    """Runs a test for every line in tests.txt"""
     with open('tests.txt') as file:
         pool = Pool(4)
         results = pool.map(validate, file)

--- a/tests.py
+++ b/tests.py
@@ -49,7 +49,6 @@ def assert_output(assertion, output_str):
 
 
 def test_stemming():
-    """Runs a test for every line in tests.txt"""
     with open('tests.txt') as file:
         pool = Pool(4)
         results = pool.map(validate, file)

--- a/tests.py
+++ b/tests.py
@@ -1,27 +1,41 @@
 from subprocess import Popen, PIPE
 
-def stem(input):
-    process = Popen(
-        args = ['hunspell', '-m', '-d', 'en_US', '-s'],
-        stdin = PIPE,
-        stdout = PIPE,
-    )
-    (stdout, stderr) = process.communicate(input)
-    return stdout.replace(input, '').strip()
+import asyncio
 
-def test_stemming():
-    with open('tests.txt') as file:
-        for line in file:
-            if line.startswith('#'):
-                continue
-            line = line.rstrip('\n').split('#')[0].strip()
-            try:
-                (input, output) = line.split(';')
-                yield validate, input.strip(), output.strip()
-            except ValueError:
-                if line:
-                    yield validate, line, line
 
-def validate(input, output):
-    stemmed = stem(input)
-    assert stemmed == output or (stemmed == '' and input == output), 'input: {}, expected: {}, actual: {}'.format(input, output, stemmed)
+class StemmingTester:
+    @staticmethod
+    def stem(inp):
+        process = Popen(
+            args=['hunspell', '-m', '-d', 'en_US', '-s'],
+            stdin=PIPE,
+            stdout=PIPE,
+        )
+        stdout, stderr = process.communicate(inp)
+        return stdout.replace(inp, ''.encode('UTF-8')).strip()
+
+    async def validate(self, input, output):
+        stemmed = self.stem(input)
+        if not (stemmed == output or (stemmed == '' and input == output)):
+            print('input: {}, expected: {}, actual: {}'.format(input, output, stemmed))
+
+    async def test(self):
+        with open('tests.txt') as file:
+            for line in file:
+                if line.startswith('#'):
+                    continue
+                line = line.rstrip('\n').split('#')[0].strip()
+                try:
+                    inp, output = line.split(';')
+                    self.validate(inp.strip(), output.strip())
+                except ValueError:
+                    if line:
+                        self.validate(line, line)
+
+
+if __name__ == '__main__':
+    tester = StemmingTester()
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(tester.test())
+    loop.close()

--- a/tests.py
+++ b/tests.py
@@ -2,34 +2,40 @@ from multiprocessing.pool import Pool
 from subprocess import Popen, PIPE
 
 
-class StemmingTester:
-    @staticmethod
-    def stem(inp):
-        process = Popen(
-            args=['hunspell', '-m', '-d', 'en_US', '-s'],
-            stdin=PIPE,
-            stdout=PIPE,
-        )
-        stdout, stderr = process.communicate(inp.encode('utf-8'))
-        return stdout.decode('utf-8').replace(inp, '').strip()
-
-    def validate(self, line):
-        if line.startswith('#'):
-            return
-
-        line = line.rstrip('\n').split('#')[0].strip()
-        try:
-            _input, output = line.split(';')
-        except ValueError:
-            _input, output = line, line
-
-        stemmed = self.stem(_input)
-        if not (stemmed == output or (stemmed == '' and _input == output)):
-            print('input: {}, expected: {}, actual: {}'.format(_input, output, stemmed))
+def stem(inp):
+    process = Popen(
+        args=['hunspell', '-m', '-d', 'en_US', '-s'],
+        stdin=PIPE,
+        stdout=PIPE,
+    )
+    stdout, stderr = process.communicate(inp.encode('utf-8'))
+    return stdout.decode('utf-8').replace(inp, '').strip()
 
 
-if __name__ == '__main__':
-    tester = StemmingTester()
-    pool = Pool(4)
+def validate(line):
+    if line.startswith('#'):
+        return
+
+    line = line.rstrip('\n').split('#')[0].strip()
+    try:
+        _input, output = line.split(';')
+    except ValueError:
+        _input, output = line, line
+
+    stemmed = stem(_input)
+    assertion = stemmed == output or (stemmed == '' and _input == output)
+    output_str = 'input: {}, expected: {}, actual: {}'.format(_input, output, stemmed)
+    return assertion, output_str
+
+
+def assert_output(assertion, output_str):
+    assert assertion, output_str
+
+
+def test_stemming():
     with open('tests.txt') as file:
-        pool.map(tester.validate, file)
+        pool = Pool(4)
+        results = pool.map(validate, file)
+    for result in results:
+        if result:
+            yield assert_output, result[0], result[1]


### PR DESCRIPTION
Brings test execution time (when all are enabled) from roughly 21 seconds to 7.
Rewrote expand.py to be object oriented
